### PR TITLE
Develop

### DIFF
--- a/BonusFFB/heavytruck/HeavyTruckSynchroGuard.cpp
+++ b/BonusFFB/heavytruck/HeavyTruckSynchroGuard.cpp
@@ -118,6 +118,7 @@ HRESULT HeavyTruckSynchroGuard::start(DeviceInfo* devPtr, SlotParameters* sPtr, 
     device->addEffect("engineVibration", { GUID_Triangle, &engineVibrationEff, DIEP_TYPESPECIFICPARAMS | DIEP_NORESTART });
 
     QObject::connect(rumbleUpdateTimer, &QTimer::timeout, this, &HeavyTruckSynchroGuard::setRumbleRPM);
+    rumbleUpdateTimer->start();
     return DI_OK;
 }
 
@@ -213,51 +214,47 @@ void HeavyTruckSynchroGuard::synchroStateChanged(HeavyTruckSynchroState newState
 
 void HeavyTruckSynchroGuard::grindingStateChanged(HeavyTruckGrindingState newState) {
     grindingState = newState;
-    if (grindingState != HeavyTruckGrindingState::OFF) {
-        // Start rumbling
-        rumbleUpdateTimer->start();
-        setRumbleRPM();
-    }
-    else {
-        // Stop rumbling
-        rumbleUpdateTimer->stop();
-        rumble.dwMagnitude = 0;
-        rumble.dwPhase = 0;
-        rumblePushback.lMagnitude = 0;
-        device->updateEffect("rumble");
-        device->updateEffect("rumblePushback");
-    }
 }
 
 void HeavyTruckSynchroGuard::setRumbleRPM() {
-    double effectScaling;
-    if (grindingState == HeavyTruckGrindingState::GRINDING_BACK) {
-        effectScaling = scaleRangeValue(fbValue, slot->grindPointDepthAsJoystickValueBack(), slot->grindPointDepthAsJoystickValueBack() + grindPushbackScalingRange);
-    }
-    else {
-        effectScaling = scaleRangeValue(fbValue, slot->grindPointDepthAsJoystickValueFwd(), slot->grindPointDepthAsJoystickValueFwd() - grindPushbackScalingRange);
-    }
-    double revMatchRumbleScaling = std::fmax(0, scaleRangeValue(std::abs(grindEffectRPM), 0, maxRevMatchRPM * 1.5));
-    unsigned long rumbleMag = grindingIntensity * clutchPercent * std::abs(effectScaling) * revMatchRumbleScaling;
-    if (synchroState == HeavyTruckSynchroState::ENTERING_SYNCH)
-    {
+    if (grindingState != HeavyTruckGrindingState::OFF) {
+        double effectScaling;
         if (grindingState == HeavyTruckGrindingState::GRINDING_BACK) {
             effectScaling = scaleRangeValue(fbValue, slot->grindPointDepthAsJoystickValueBack(), slot->grindPointDepthAsJoystickValueBack() + grindPushbackScalingRange);
         }
         else {
-            effectScaling = scaleRangeValue(fbValue, slot->grindPointDepthAsJoystickValueFwd(), slot->grindPointDepthAsJoystickValueFwd() - grindPushbackScalingRange) * -1;
+            effectScaling = scaleRangeValue(fbValue, slot->grindPointDepthAsJoystickValueFwd(), slot->grindPointDepthAsJoystickValueFwd() - grindPushbackScalingRange);
         }
-        double revMatchPushbackScaling = std::fmax(0.25, scaleRangeValue(std::abs(grindEffectRPM), 0, maxRevMatchRPM));
-        rumblePushback.lMagnitude = FFB_MAX * effectScaling * clutchPercent * revMatchPushbackScaling * -1; // AB9 1.1.3.4 firmware force inversion
-        //qDebug() << "rumblePushback.lMagnitude: " << rumblePushback.lMagnitude;
-        device->updateEffect("rumblePushback");
+        double revMatchRumbleScaling = std::fmax(0, scaleRangeValue(std::abs(grindEffectRPM), 0, maxRevMatchRPM * 1.5));
+        unsigned long rumbleMag = grindingIntensity * clutchPercent * std::abs(effectScaling) * revMatchRumbleScaling;
+        if (synchroState == HeavyTruckSynchroState::ENTERING_SYNCH)
+        {
+            if (grindingState == HeavyTruckGrindingState::GRINDING_BACK) {
+                effectScaling = scaleRangeValue(fbValue, slot->grindPointDepthAsJoystickValueBack(), slot->grindPointDepthAsJoystickValueBack() + grindPushbackScalingRange);
+            }
+            else {
+                effectScaling = scaleRangeValue(fbValue, slot->grindPointDepthAsJoystickValueFwd(), slot->grindPointDepthAsJoystickValueFwd() - grindPushbackScalingRange) * -1;
+            }
+            double revMatchPushbackScaling = std::fmax(0.25, scaleRangeValue(std::abs(grindEffectRPM), 0, maxRevMatchRPM));
+            rumblePushback.lMagnitude = FFB_MAX * effectScaling * clutchPercent * revMatchPushbackScaling * -1; // AB9 1.1.3.4 firmware force inversion
+            //qDebug() << "rumblePushback.lMagnitude: " << rumblePushback.lMagnitude;
+            device->updateEffect("rumblePushback");
+        }
+        DWORD period = 6e7 / std::abs(grindEffectRPM);
+        if (period != rumble.dwPeriod || rumbleMag != rumble.dwMagnitude)
+        {
+            rumble.dwPeriod = period;
+            rumble.dwMagnitude = rumbleMag;
+            device->updateEffect("rumble");
+        }
     }
-    DWORD period = 6e7 / std::abs(grindEffectRPM);
-    if (period != rumble.dwPeriod || rumbleMag != rumble.dwMagnitude)
-    {
-        rumble.dwPeriod = period;
-        rumble.dwMagnitude = rumbleMag;
+    else {
+        // Stop rumbling
+        //rumbleUpdateTimer->stop();
+        rumble.dwMagnitude = 0;
+        rumblePushback.lMagnitude = 0;
         device->updateEffect("rumble");
+        device->updateEffect("rumblePushback");
     }
 }
 

--- a/BonusFFB/heavytruck/HeavyTruckSynchroGuard.cpp
+++ b/BonusFFB/heavytruck/HeavyTruckSynchroGuard.cpp
@@ -115,7 +115,7 @@ HRESULT HeavyTruckSynchroGuard::start(DeviceInfo* devPtr, SlotParameters* sPtr, 
     engineVibrationEff.cbTypeSpecificParams = sizeof(DIPERIODIC);
     engineVibrationEff.lpvTypeSpecificParams = &engineVibration;
     engineVibrationEff.dwStartDelay = 0;
-    device->addEffect("engineVibration", { GUID_Sine, &engineVibrationEff, DIEP_TYPESPECIFICPARAMS | DIEP_NORESTART });
+    device->addEffect("engineVibration", { GUID_Triangle, &engineVibrationEff, DIEP_TYPESPECIFICPARAMS | DIEP_NORESTART });
 
     QObject::connect(rumbleUpdateTimer, &QTimer::timeout, this, &HeavyTruckSynchroGuard::setRumbleRPM);
     return DI_OK;
@@ -146,7 +146,7 @@ void HeavyTruckSynchroGuard::updateTorqueLock(QPair<int, int> pedalValues, QPair
     throttlePercent = telemetry->getThrottlePercent();
     int fbValue = joystickValues.second;
     // Update keep-in-gear spring
-    if ((synchroState == HeavyTruckSynchroState::IN_SYNCH || synchroState == HeavyTruckSynchroState::EXITING_SYNCH)) {
+    if ((synchroState == HeavyTruckSynchroState::IN_SYNCH || synchroState == HeavyTruckSynchroState::EXITING_SYNCH) && applyIdleTorqueLock) {
         // Assume throttle is applied, use pedal values for keep-in-gear force scaling
         double scaling = scaleRangeValue(throttlePercent, 0.01, 0.06);
         int maxStrength = keepInGearSpringMaxCoefficient;
@@ -162,14 +162,14 @@ void HeavyTruckSynchroGuard::updateTorqueLock(QPair<int, int> pedalValues, QPair
         }
         if (fbValue < JOY_MIDPOINT && fbValue > slot->depthAsJoystickValueFwd()) {
             keepInGearSpring.lOffset = slot->depthAsFFBOffsetFwd() - (std::abs(joystickPositionToFFBOffset(fbValue) - slot->depthAsFFBOffsetFwd()) * offsetScaling);
-            keepInGearSpring.lNegativeCoefficient = maxStrength * scaleRangeValue(fbValue, slot->depthAsJoystickValueFwd(), slot->depthAsJoystickValueFwd() + 4000) * scaling * -1; // AB9 1.1.3.4 firmware force inversion
-            keepInGearSpring.lPositiveCoefficient = maxStrength * scaleRangeValue(fbValue, slot->depthAsJoystickValueFwd(), slot->depthAsJoystickValueFwd() + 4000) * scaling * -1; // AB9 1.1.3.4 firmware force inversion
+            keepInGearSpring.lNegativeCoefficient = maxStrength * scaleRangeValue(fbValue, slot->depthAsJoystickValueFwd(), slot->depthAsJoystickValueFwd() + 4000) * scaling * clutchPercent * -1; // AB9 1.1.3.4 firmware force inversion
+            keepInGearSpring.lPositiveCoefficient = maxStrength * scaleRangeValue(fbValue, slot->depthAsJoystickValueFwd(), slot->depthAsJoystickValueFwd() + 4000) * scaling * clutchPercent * -1; // AB9 1.1.3.4 firmware force inversion
             
         }
         else if (fbValue > JOY_MIDPOINT && fbValue < slot->depthAsJoystickValueBack()) {
             keepInGearSpring.lOffset = slot->depthAsFFBOffsetBack() + (std::abs(joystickPositionToFFBOffset(fbValue) - slot->depthAsFFBOffsetBack()) * offsetScaling);
-            keepInGearSpring.lNegativeCoefficient = maxStrength * scaleRangeValue(fbValue, slot->depthAsJoystickValueBack(), slot->depthAsJoystickValueBack() - 4000) * scaling * -1; // AB9 1.1.3.4 firmware force inversion
-            keepInGearSpring.lPositiveCoefficient = maxStrength * scaleRangeValue(fbValue, slot->depthAsJoystickValueBack(), slot->depthAsJoystickValueBack() - 4000) * scaling * -1; // AB9 1.1.3.4 firmware force inversion
+            keepInGearSpring.lNegativeCoefficient = maxStrength * scaleRangeValue(fbValue, slot->depthAsJoystickValueBack(), slot->depthAsJoystickValueBack() - 4000) * scaling * clutchPercent * -1; // AB9 1.1.3.4 firmware force inversion
+            keepInGearSpring.lPositiveCoefficient = maxStrength * scaleRangeValue(fbValue, slot->depthAsJoystickValueBack(), slot->depthAsJoystickValueBack() - 4000) * scaling * clutchPercent * -1; // AB9 1.1.3.4 firmware force inversion
         }
         else {
             keepInGearSpring.lNegativeCoefficient = 0;
@@ -185,6 +185,15 @@ void HeavyTruckSynchroGuard::updateTorqueLock(QPair<int, int> pedalValues, QPair
         handsOffCondition[1] = { 0, handsOffDamper, handsOffDamper };
     }
     else {
+        if (synchroState == HeavyTruckSynchroState::IN_SYNCH && !applyIdleTorqueLock && (fbValue <= slot->depthAsJoystickValueFwd() || fbValue >= slot->depthAsJoystickValueBack())) {
+            // Only start applying the idle torque lock if the stick has reached the end of the slot
+            applyIdleTorqueLock = true;
+            //qDebug() << "Enabling idle torque lock";
+        }
+        else {
+            applyIdleTorqueLock = false;
+            //qDebug() << "Disabling idle torque lock";
+        }
         keepInGearSpring.lNegativeCoefficient = 0;
         keepInGearSpring.lPositiveCoefficient = 0;
         torqueLoadSpring.lNegativeCoefficient = 0;

--- a/BonusFFB/heavytruck/HeavyTruckSynchroGuard.cpp
+++ b/BonusFFB/heavytruck/HeavyTruckSynchroGuard.cpp
@@ -216,7 +216,11 @@ void HeavyTruckSynchroGuard::grindingStateChanged(HeavyTruckGrindingState newSta
     grindingState = newState;
 }
 
+/// <summary>
+/// Invoked via a periodic timer set to run every millisecond
+/// </summary>
 void HeavyTruckSynchroGuard::setRumbleRPM() {
+    // Start rumbling
     if (grindingState != HeavyTruckGrindingState::OFF) {
         double effectScaling;
         if (grindingState == HeavyTruckGrindingState::GRINDING_BACK) {
@@ -250,11 +254,14 @@ void HeavyTruckSynchroGuard::setRumbleRPM() {
     }
     else {
         // Stop rumbling
-        //rumbleUpdateTimer->stop();
-        rumble.dwMagnitude = 0;
-        rumblePushback.lMagnitude = 0;
-        device->updateEffect("rumble");
-        device->updateEffect("rumblePushback");
+        if (rumble.dwMagnitude != 0) {
+            rumble.dwMagnitude = 0;
+            device->updateEffect("rumble");
+        }
+        if (rumblePushback.lMagnitude != 0) {
+            rumblePushback.lMagnitude = 0;
+            device->updateEffect("rumblePushback");
+        }
     }
 }
 

--- a/BonusFFB/heavytruck/HeavyTruckSynchroGuard.cpp
+++ b/BonusFFB/heavytruck/HeavyTruckSynchroGuard.cpp
@@ -227,30 +227,18 @@ void HeavyTruckSynchroGuard::setRumbleRPM() {
             effectScaling = scaleRangeValue(fbValue, slot->grindPointDepthAsJoystickValueBack(), slot->grindPointDepthAsJoystickValueBack() + grindPushbackScalingRange);
         }
         else {
-            effectScaling = scaleRangeValue(fbValue, slot->grindPointDepthAsJoystickValueFwd(), slot->grindPointDepthAsJoystickValueFwd() - grindPushbackScalingRange);
+            effectScaling = scaleRangeValue(fbValue, slot->grindPointDepthAsJoystickValueFwd(), slot->grindPointDepthAsJoystickValueFwd() - grindPushbackScalingRange) * -1;
         }
-        double revMatchRumbleScaling = std::fmax(0, scaleRangeValue(std::abs(grindEffectRPM), 0, maxRevMatchRPM * 1.5));
-        unsigned long rumbleMag = grindingIntensity * clutchPercent * std::abs(effectScaling) * revMatchRumbleScaling;
-        if (synchroState == HeavyTruckSynchroState::ENTERING_SYNCH)
-        {
-            if (grindingState == HeavyTruckGrindingState::GRINDING_BACK) {
-                effectScaling = scaleRangeValue(fbValue, slot->grindPointDepthAsJoystickValueBack(), slot->grindPointDepthAsJoystickValueBack() + grindPushbackScalingRange);
-            }
-            else {
-                effectScaling = scaleRangeValue(fbValue, slot->grindPointDepthAsJoystickValueFwd(), slot->grindPointDepthAsJoystickValueFwd() - grindPushbackScalingRange) * -1;
-            }
-            double revMatchPushbackScaling = std::fmax(0.25, scaleRangeValue(std::abs(grindEffectRPM), 0, maxRevMatchRPM));
-            rumblePushback.lMagnitude = FFB_MAX * effectScaling * clutchPercent * revMatchPushbackScaling * -1; // AB9 1.1.3.4 firmware force inversion
-            //qDebug() << "rumblePushback.lMagnitude: " << rumblePushback.lMagnitude;
-            device->updateEffect("rumblePushback");
-        }
-        DWORD period = 6e7 / std::abs(grindEffectRPM);
-        if (period != rumble.dwPeriod || rumbleMag != rumble.dwMagnitude)
-        {
-            rumble.dwPeriod = period;
-            rumble.dwMagnitude = rumbleMag;
-            device->updateEffect("rumble");
-        }
+        double revMatchPushbackScaling = scaleRangeValue(std::abs(grindEffectRPM), 0, maxRevMatchRPM);
+        rumblePushback.lMagnitude = FFB_MAX * effectScaling * clutchPercent * revMatchPushbackScaling * -1; // AB9 1.1.3.4 firmware force inversion
+        device->updateEffect("rumblePushback");
+        long smoothedRPM = long(grindEffectRPM) - long(grindEffectRPM) % 10;
+        double revMatchRumbleScaling = scaleRangeValue(std::abs(smoothedRPM), 0, 400);
+        // Apply some smoothing since the AB9 seems to struggle with changing periodic effects too frequently
+        rumble.dwPeriod = 6e7 / std::abs(smoothedRPM);
+        rumble.dwMagnitude = unsigned long(grindingIntensity * clutchPercent * std::abs(effectScaling) * revMatchRumbleScaling);
+        //qDebug() << "revMatchRumbleScaling: " << revMatchRumbleScaling << "smoothedRPM: " << smoothedRPM <<  "rumble.dwPeriod: " << rumble.dwPeriod << "rumble.dwMagnitude: " << rumble.dwMagnitude;
+        device->updateEffect("rumble");
     }
     else {
         // Stop rumbling

--- a/BonusFFB/heavytruck/HeavyTruckSynchroGuard.h
+++ b/BonusFFB/heavytruck/HeavyTruckSynchroGuard.h
@@ -84,5 +84,5 @@ private:
 
 	double clutchPercent = 0;
 	double throttlePercent = 0;
-
+	bool applyIdleTorqueLock = false;
 };

--- a/BonusFFB/version.h
+++ b/BonusFFB/version.h
@@ -5,6 +5,6 @@
 
 #define MAJOR_VERSION 3
 #define MINOR_VERSION 1
-#define PATCH_VERSION 1
+#define PATCH_VERSION 2
 
 #endif

--- a/Installer/Package.wxs
+++ b/Installer/Package.wxs
@@ -1,5 +1,5 @@
 ﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
-  <Package Name="Bonus FFB" Manufacturer="Ken Monteith" Version="3.1.1" UpgradeCode="ea04bc92-dde2-42ca-b2a4-ad303163fec3">
+  <Package Name="Bonus FFB" Manufacturer="Ken Monteith" Version="3.1.2" UpgradeCode="ea04bc92-dde2-42ca-b2a4-ad303163fec3">
     <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
 
 	<MediaTemplate EmbedCab="yes" />


### PR DESCRIPTION
### Heavy truck mode

- Fixed idle torque lock effect, it now scales down with clutch pedal application and doesn't apply until the stick is fully slotted
- Changed the engine rumble effect shape from sine wave to triangle
- Refactored grind effects
- Added grind effect smoothing; the AB9 struggles with updating periodic effects too frequently.